### PR TITLE
Expose root status endpoint with config and message counts

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -272,6 +272,16 @@ export class RelayDb {
       )
       .run(update.status, update.mailgunId ?? null, update.error ?? null, updatedAt, xmtpMsgId);
   }
+
+  countInboundEmails(): number {
+    const row = this.db.prepare('SELECT COUNT(*) as count FROM inbound_email').get() as { count: number };
+    return row.count;
+  }
+
+  countInboundXmtpMessages(): number {
+    const row = this.db.prepare('SELECT COUNT(*) as count FROM outbound_request').get() as { count: number };
+    return row.count;
+  }
 }
 
 function computeInboundDedupeKey(input: InboundEmailInsert): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { DedupingQueue, sleep } from './queue';
 import { log } from './log';
 import { makeEmailSendResultV1, emailSendV1Schema } from './messages';
 import { sendEmailViaMailgun } from './mailgunSend';
-import { startHttpServer } from './httpServer';
+import { startHttpServer, type PublicConfig } from './httpServer';
 import { createEnsProvider, createXmtpClient, getInboxIdByAddress, resolveXmtpAddress } from './xmtp';
 
 dotenv.config();
@@ -65,6 +65,20 @@ async function main(): Promise<void> {
     getDeanConversation,
   });
 
+  const publicConfig: PublicConfig = {
+    port: config.port,
+    dataDir: config.dataDir,
+    inboundEmailTo: config.inboundEmailTo,
+    xmtpEnv: config.xmtpEnv,
+    xmtpDeanAddressOrEns: config.xmtpDeanAddressOrEns,
+    adminXmtpAddressOrEns: config.adminXmtpAddressOrEns,
+    ethRpcUrl: config.ethRpcUrl,
+    mailgunDomain: config.mailgunDomain,
+    mailgunFrom: config.mailgunFrom,
+    webhookRateLimit: config.webhookRateLimit,
+    maxInboundFieldSizeBytes: config.maxInboundFieldSizeBytes,
+  };
+
   await startHttpServer({
     db,
     port: config.port,
@@ -73,6 +87,7 @@ async function main(): Promise<void> {
     enqueueInboundEmail: (id) => inboundQueue.enqueue(id),
     webhookRateLimit: config.webhookRateLimit,
     maxInboundFieldSizeBytes: config.maxInboundFieldSizeBytes,
+    publicConfig,
   });
 
   startXmtpOutboundLoop({


### PR DESCRIPTION
## Summary
- add GET / endpoint returning public configuration and message counts for quick inspection
- add database helpers to count inbound emails and inbound XMTP messages
- wire configuration details from startup into the HTTP server for safe exposure

## Testing
- npm run typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694352575c7483238ad8b24b55250582)